### PR TITLE
refactor search

### DIFF
--- a/src/bin/search/data.rs
+++ b/src/bin/search/data.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Package {
+    pub attribute: String,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub long_description: Option<String>,
+}
+
+impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
+    type Error = rusqlite::Error;
+
+    fn try_from(row: &'r rusqlite::Row<'d>) -> Result<Self, Self::Error> {
+        let attribute: String = row.get("attribute")?;
+        // let store_path: String = row.get("store_path")?;
+        let name: Option<String> = row.get("name")?;
+        let version: Option<String> = row.get("version")?;
+        let description: Option<String> = row.get("description")?;
+        let homepage: Option<String> = row.get("homepage")?;
+        let long_description: Option<String> = row.get("long_description")?;
+
+        Ok(Package {
+            attribute,
+            name,
+            version,
+            description,
+            homepage,
+            long_description,
+        })
+    }
+}

--- a/src/bin/search/fuzzy.rs
+++ b/src/bin/search/fuzzy.rs
@@ -1,0 +1,53 @@
+use std::time::Instant;
+
+use eyre::Context;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use rusqlite::functions::Context as FunctionContext;
+use rusqlite::{functions::FunctionFlags, Connection};
+
+use crate::data::Package;
+
+pub fn search(query_str: &str, db: &Connection, num_results: u32) -> eyre::Result<Vec<Package>> {
+    db.create_scalar_function(
+        "fuzzy_score",
+        2,
+        FunctionFlags::SQLITE_UTF8,
+        scalar_fuzzy_score,
+    )
+    .context("unable to install `fuzzy_score` function")?;
+
+    let mut query = db
+        .prepare(
+            r#"
+SELECT *
+FROM packages
+ORDER BY fuzzy_score(name, ?1) DESC
+LIMIT ?2
+            "#,
+        )
+        .context("unable to prepare search query")?;
+
+    let start = Instant::now();
+
+    let res = query
+        .query_map(rusqlite::params![query_str, num_results], |r| Package::try_from(r))
+        .map(|res| res.collect::<Result<Vec<_>, _>>().context("error parsing results"))
+        .context("unable to execute query")?;
+
+    let elapsed = start.elapsed();
+    eprintln!("got results in {} ms", elapsed.as_millis());
+
+    res
+}
+
+fn scalar_fuzzy_score(ctx: &FunctionContext) -> rusqlite::Result<i64> {
+    lazy_static::lazy_static! {
+      static ref MATCHER: SkimMatcherV2 = SkimMatcherV2::default();
+    }
+
+    let choice = ctx.get::<String>(0)?;
+    let pattern = ctx.get::<String>(1)?;
+
+    Ok(MATCHER.fuzzy_match(&choice, &pattern).unwrap_or(0))
+}

--- a/src/bin/search/main.rs
+++ b/src/bin/search/main.rs
@@ -1,14 +1,11 @@
+mod data;
+mod fuzzy;
 use std::io::stdout;
 use std::path::PathBuf;
-use std::time::Instant;
 
 use clap::{Parser, ValueEnum};
 use eyre::Context;
 use eyre::Result;
-use fuzzy_matcher::skim::SkimMatcherV2;
-use fuzzy_matcher::FuzzyMatcher;
-use rusqlite::functions::Context as FunctionContext;
-use rusqlite::functions::FunctionFlags;
 use rusqlite::OpenFlags;
 
 #[derive(Debug, Parser)]
@@ -41,76 +38,10 @@ fn main() -> Result<()> {
     )
     .context("unable to read index")?;
 
-    conn.create_scalar_function(
-        "fuzzy_score",
-        2,
-        FunctionFlags::SQLITE_UTF8,
-        scalar_fuzzy_score,
-    )
-    .context("unable to install `fuzzy_score` function")?;
+    let results = fuzzy::search(opts.query.as_str(), &conn, opts.num_results)
+        .context("error getting results")?;
 
-    let mut query = conn
-        .prepare(
-            r#"
-SELECT *
-FROM packages
-ORDER BY fuzzy_score(name, ?1) DESC
-LIMIT ?2
-            "#,
-        )
-        .context("unable to prepare search query")?;
-
-    let start = Instant::now();
-
-    let mut results = query
-        .query(rusqlite::params![opts.query, opts.num_results])
-        .context("unable to execute query")?;
-
-    let mut result_json_object = Vec::<serde_json::Value>::with_capacity(opts.num_results as _);
-
-    loop {
-        let row = results.next().context("error collecting query results")?;
-
-        let Some(row) = row else {
-            break;
-        };
-
-        let attribute: String = row.get("attribute").context("error reading column")?;
-        // let store_path: String = row.get("store_path").context("error reading column")?;
-        let name: Option<String> = row.get("name").context("error reading column")?;
-        let version: Option<String> = row.get("version").context("error reading column")?;
-        let description: Option<String> = row.get("description").context("error reading column")?;
-        let homepage: Option<String> = row.get("homepage").context("error reading column")?;
-        let long_description: Option<String> = row
-            .get("long_description")
-            .context("error reading column")?;
-
-        result_json_object.push(serde_json::json!({
-          "attribute": attribute,
-          // "storePath": store_path,
-          "name": name,
-          "version": version,
-          "description": description,
-          "homepage": homepage,
-          "longDescription": long_description,
-        }));
-    }
-
-    serde_json::to_writer(stdout(), &result_json_object).context("error printing result")?;
-
-    let elapsed = start.elapsed();
-    eprintln!("finished in {} ms", elapsed.as_millis());
+    serde_json::to_writer(stdout(), &results).context("error printing results")?;
 
     Ok(())
-}
-
-fn scalar_fuzzy_score(ctx: &FunctionContext) -> rusqlite::Result<i64> {
-    lazy_static::lazy_static! {
-      static ref MATCHER: SkimMatcherV2 = SkimMatcherV2::default();
-    }
-
-    let choice = ctx.get::<String>(0)?;
-    let pattern = ctx.get::<String>(1)?;
-
-    Ok(MATCHER.fuzzy_match(&choice, &pattern).unwrap_or(0))
 }


### PR DESCRIPTION
Why
===

break out to better support multiple operation types

What changed
============

- define rust struct for results (query all rows of db)
- move `search` function to its own module called `fuzzy`

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
