### PR TITLE
flake: generate registry with nix function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,5 +93,9 @@
             });
         };
       };
+
+      flake = args: {
+        lib = import ./lib args;
+      };
     };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,86 @@
+{lib, ...}: let
+in {
+  genRegistry = pkgs: let
+    inherit (builtins) currentSystem deepSeq listToAttrs map parseDrvName seq tryEval;
+    inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals traceVal;
+
+    registerPackage = name: value: let
+      safeValue = tryEval value;
+
+      safeRegistryValue = tryEval (deepSeq registryValue registryValue);
+      registryValue = {
+        pname = value.pname or (parseDrvName value.name).name or null;
+        version = value.version or null;
+
+        meta = {
+          description = value.meta.description or null;
+          homepage = value.meta.homepage or null;
+          license = value.meta.license or null;
+          longDescription = value.meta.longDescription or null;
+        };
+      };
+
+      platformForAvailability = {system = pkgs.system or currentSystem;};
+      isAvailableOn = tryEval (lib.meta.availableOn platformForAvailability safeValue.value);
+      available = safeValue.success && isDerivation value && isAvailableOn.success && isAvailableOn.value;
+
+      checkRegistryCondition = prev: {
+        reason,
+        ok,
+      }: let
+        isOk =
+          if !ok
+          then seq (traceVal "${name}: ${reason}") false
+          else true;
+      in
+        # change to `prev && isOk` to debug why a value isn't included
+        prev && ok;
+
+      shouldBeInRegistry = foldl checkRegistryCondition true [
+        {
+          reason = "not available on ${platformForAvailability.system}";
+          ok = available;
+        }
+        {
+          reason = "failed eval";
+          ok = safeRegistryValue.success;
+        }
+        {
+          reason = "no pname";
+          ok = safeRegistryValue.value.pname != null;
+        }
+      ];
+    in
+      optional shouldBeInRegistry {
+        inherit name;
+        value = let
+          filtered-toplevel-attrs = filterAttrs (_: v: v != null) safeRegistryValue.value;
+          filtered-meta-attrs = filterAttrs (_: v: v != null) safeRegistryValue.value.meta;
+        in
+          filtered-toplevel-attrs // {meta = filtered-meta-attrs;};
+      };
+
+    registerScope = scope-name: scope: let
+      safeScope = tryEval scope;
+
+      list-of-scope-packages = mapAttrsToList registerPackage safeScope.value;
+      scope-registry-inner = flatten list-of-scope-packages;
+      scope-registry =
+        map (item: {
+          name = "${scope-name}.${item.name}";
+          value = item.value;
+        })
+        scope-registry-inner;
+
+      shouldBeInRegistry = safeScope.success && safeScope.value ? recurseForDerivations && safeScope.value.recurseForDerivations;
+    in
+      optionals shouldBeInRegistry scope-registry;
+
+    list-of-registry-packages = mapAttrsToList registerPackage pkgs;
+    registry-items = flatten list-of-registry-packages;
+
+    scoped-registries = flatten (mapAttrsToList registerScope pkgs);
+    registry = listToAttrs (registry-items ++ scoped-registries);
+  in
+    registry;
+}

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -91,7 +91,7 @@ VALUES (?, ?, ?, ?, ?, ?)
 
     for (attr, info) in registry.into_iter() {
         let name = info.pname.as_ref().unwrap_or(&attr).as_str();
-        let version = info.version.as_ref().unwrap().as_str();
+        let version = info.version.as_ref();
         let description = info
             .meta
             .as_ref()


### PR DESCRIPTION
Why
===

it'd be *really* nice to generate indices purely.

What changed
============

- added flake attribute `lib`
- defined `lib.genRegistry` which generates a `rippkgs-index`-compatible registry object in nix

Test plan
=========

```
nix eval .#lib.genRegistry --show-trace --apply 'f: f (import <nixpkgs> { config = import <nixpkgs/pkgs/top-level/packages-config.nix> // { allowUnsupportedSystem = true; }; })' --impure --json
```

note that `--impure` is only necessary for `<nixpkgs>` syntax