### PR TITLE
genRegistry: just use the system to index for as a param

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,6 @@
 {lib, ...}: let
 in {
-  genRegistry = pkgs: let
+  genRegistry = platform: pkgs: let
     inherit (builtins) deepSeq listToAttrs map parseDrvName seq tryEval;
     inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals traceVal;
 
@@ -20,7 +20,7 @@ in {
         };
       };
 
-      platformForAvailability = {system = pkgs.system or builtins.currentSystem;};
+      platformForAvailability = {system = platform;};
       isAvailableOn = tryEval (lib.meta.availableOn platformForAvailability safeValue.value);
       available = safeValue.success && isDerivation value && isAvailableOn.success && isAvailableOn.value;
 


### PR DESCRIPTION
Why
===

sometimes `pkgs.system` doesn't exist for some reason, and we need to be able to generate the registry in a pure environment. if we're gonna require it in a parameter, might as well simplify things a bit and only rely on the parameter

What changed
============

- added new 1st param to `genRegistry`
- use only the value of that 1st param in the `lib.meta.availableOn` call

Test plan
=========

n/a
