### PR TITLE
add out paths to results

### DIFF
--- a/src/bin/index/data.rs
+++ b/src/bin/index/data.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -5,6 +7,7 @@ pub struct PackageInfo {
     pub pname: Option<String>,
     pub version: Option<String>,
     pub meta: Option<PackageMeta>,
+    pub outputs: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -68,6 +68,7 @@ CREATE TABLE packages (
     attribute TEXT NOT NULL,
     name TEXT,
     version TEXT,
+    outPath TEXT,
     description TEXT,
     homepage TEXT,
     long_description TEXT,
@@ -81,8 +82,8 @@ CREATE TABLE packages (
     let mut create_row_query = conn
         .prepare(
             r#"
-INSERT INTO packages (attribute, name, version, description, homepage, long_description)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO packages (attribute, name, version, outPath, description, homepage, long_description)
+VALUES (?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .context("unable to prepare INSERT query")?;
@@ -92,6 +93,10 @@ VALUES (?, ?, ?, ?, ?, ?)
     for (attr, info) in registry.into_iter() {
         let name = info.pname.as_ref().unwrap_or(&attr).as_str();
         let version = info.version.as_ref();
+        let out_path = info
+            .outputs
+            .map(|outs| outs.get("out").map(String::to_owned))
+            .flatten();
         let description = info
             .meta
             .as_ref()
@@ -108,6 +113,7 @@ VALUES (?, ?, ?, ?, ?, ?)
                 attr,
                 name,
                 version,
+                out_path,
                 description,
                 None::<String>,
                 long_description


### PR DESCRIPTION
Why
===

This will unblock some really cool features :) allows for detection of if a package is available on the local FS!

What changed
============

- add new `outputs` attr to nix-generated registry
- add new `outPath` column in db

Test plan
=========

1. `nix eval -L github:replit/rippkgs/cad/out-paths#lib.genRegistry --apply 'f: f builtins.currentSystem (import <nixpkgs> { config = { allowUnsupportedSystem = true; }; })' --impure --json --refresh >nixpkgs.json`
2. `jq .zsh nixpkgs.json` has `outputs` field which is an object that contains a field `out`. on darwin using my pinned nixpkgs channel:
```json
{
  "meta": {
    "description": "The Z shell",
    "homepage": "https://www.zsh.org/",
    "license": "MIT-like",
    "longDescription": "Zsh is a UNIX command interpreter (shell) usable as an interactive login\nshell and as a shell script command processor.  Of the standard shells,\nzsh most closely resembles ksh but includes many enhancements.  Zsh has\ncommand line editing, builtin spelling correction, programmable command\ncompletion, shell functions (with autoloading), a history mechanism, and\na host of other features.\n"
  },
  "outputs": {
    "doc": "/nix/store/xfznbc3y759ic5mv01hz826f3q3qv1mf-zsh-5.9-doc",
    "info": "/nix/store/93dw55zwzz4vy7ghb4pabd2w7px7zwjf-zsh-5.9-info",
    "man": "/nix/store/daa2zxqhzbxr88f77hh2sq2041jf19cy-zsh-5.9-man",
    "out": "/nix/store/lapg988lmdl9ajs3kg4j2v8i1wlgbqdw-zsh-5.9"
  },
  "pname": "zsh",
  "version": "5.9"
}
```
3. `nix run -L github:replit/rippkgs/cad/out-paths#rippkgs-index -- --output nixpkgs.sqlite --registry nixpkgs.json`
4. `nix run -L github:replit/rippkgs/cad/out-paths#rippkgs -- --index nixpkgs.sqlite zsh | jq` shows an entry with the same info as step 2's output