### PR TITLE
genRegistry: strip /nix/store/ prefix from out paths

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,7 +2,7 @@
 in {
   genRegistry = platform: pkgs: let
     inherit (builtins) deepSeq filter listToAttrs map parseDrvName seq tryEval;
-    inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals traceVal;
+    inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals removePrefix traceVal;
 
     registerPackage = name: value: let
       safeValue = tryEval value;
@@ -12,10 +12,10 @@ in {
       registryValue = {
         pname = safeVal.pname or (parseDrvName safeVal.name).name or null;
         version = safeVal.version or null;
-        outputs = let
+        storePaths = let
           outputs-list = map (out: {
             name = out;
-            value = safeVal.${out}.outPath;
+            value = removePrefix "/nix/store/" safeVal.${out}.outPath;
           }) (safeVal.outputs or []);
           relevant-outputs = filter ({name, ...}: name == "out") outputs-list;
         in

--- a/src/bin/index/data.rs
+++ b/src/bin/index/data.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PackageInfo {
     pub pname: Option<String>,
     pub version: Option<String>,
     pub meta: Option<PackageMeta>,
-    pub outputs: Option<HashMap<String, String>>,
+    pub store_paths: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +50,17 @@ mod tests {
         assert_matches!(
             serde_json::from_str::<super::OneOrList<String>>(r#""hi""#),
             Ok(super::OneOrList::One(_))
+        );
+    }
+
+    #[test]
+    fn store_paths() {
+        assert_matches!(
+            serde_json::from_str::<super::PackageInfo>(r#"{"storePaths": {"out": "hi"}}"#),
+            Ok(super::PackageInfo {
+                store_paths: Some(store_paths),
+                ..
+            }) if store_paths.len() == 1 && store_paths["out"] == "hi"
         );
     }
 }

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -94,7 +94,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
         let name = info.pname.as_ref().unwrap_or(&attr).as_str();
         let version = info.version.as_ref();
         let out_path = info
-            .outputs
+            .store_paths
             .map(|outs| outs.get("out").map(String::to_owned))
             .flatten();
         let description = info


### PR DESCRIPTION
Why
===

it's a small optimization :)

What changed
============

- rename `outPaths` attr in registry to `storePaths`
- strip `/nix/store/` prefix from store paths in registry generation

Test plan
=========

same as #8 but instead of the attr being `outPaths` it should be `storePaths`, and `out` shouldn't have `/nix/store/` prefix
```json
{
  "meta": {
    "description": "A safe, concurrent, practical language",
    "homepage": "https://www.rust-lang.org/",
    "license": [
      {
        "deprecated": false,
        "free": true,
        "fullName": "MIT License",
        "redistributable": true,
        "shortName": "mit",
        "spdxId": "MIT",
        "url": "https://spdx.org/licenses/MIT.html"
      },
      {
        "deprecated": false,
        "free": true,
        "fullName": "Apache License 2.0",
        "redistributable": true,
        "shortName": "asl20",
        "spdxId": "Apache-2.0",
        "url": "https://spdx.org/licenses/Apache-2.0.html"
      }
    ]
  },
  "pname": "rustc",
  "storePaths": {
    "out": "wg8azvp3dabj9ph96w4mzf9j3nc1lyy4-rustc-1.73.0"
  },
  "version": "1.73.0"
}
```