### PR TITLE
search: return store paths

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,7 +2,7 @@
 in {
   genRegistry = platform: pkgs: let
     inherit (builtins) deepSeq filter listToAttrs map parseDrvName seq tryEval;
-    inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals traceVal;
+    inherit (lib) filterAttrs flatten foldl isDerivation mapAttrsToList optional optionals removePrefix traceVal;
 
     registerPackage = name: value: let
       safeValue = tryEval value;
@@ -12,10 +12,10 @@ in {
       registryValue = {
         pname = safeVal.pname or (parseDrvName safeVal.name).name or null;
         version = safeVal.version or null;
-        outputs = let
+        storePaths = let
           outputs-list = map (out: {
             name = out;
-            value = safeVal.${out}.outPath;
+            value = removePrefix "/nix/store/" safeVal.${out}.outPath;
           }) (safeVal.outputs or []);
           relevant-outputs = filter ({name, ...}: name == "out") outputs-list;
         in

--- a/src/bin/index/data.rs
+++ b/src/bin/index/data.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PackageInfo {
     pub pname: Option<String>,
     pub version: Option<String>,
     pub meta: Option<PackageMeta>,
-    pub outputs: Option<HashMap<String, String>>,
+    pub store_paths: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +50,17 @@ mod tests {
         assert_matches!(
             serde_json::from_str::<super::OneOrList<String>>(r#""hi""#),
             Ok(super::OneOrList::One(_))
+        );
+    }
+
+    #[test]
+    fn store_paths() {
+        assert_matches!(
+            serde_json::from_str::<super::PackageInfo>(r#"{"storePaths": {"out": "hi"}}"#),
+            Ok(super::PackageInfo {
+                store_paths: Some(store_paths),
+                ..
+            }) if store_paths.len() == 1 && store_paths["out"] == "hi"
         );
     }
 }

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -94,7 +94,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
         let name = info.pname.as_ref().unwrap_or(&attr).as_str();
         let version = info.version.as_ref();
         let out_path = info
-            .outputs
+            .store_paths
             .map(|outs| outs.get("out").map(String::to_owned))
             .flatten();
         let description = info

--- a/src/bin/search/data.rs
+++ b/src/bin/search/data.rs
@@ -8,6 +8,7 @@ pub struct Package {
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub long_description: Option<String>,
+    pub store_path: Option<String>,
 }
 
 impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
@@ -15,7 +16,7 @@ impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
 
     fn try_from(row: &'r rusqlite::Row<'d>) -> Result<Self, Self::Error> {
         let attribute: String = row.get("attribute")?;
-        // let store_path: String = row.get("store_path")?;
+        let store_path: Option<String> = row.get("outPath")?;
         let name: Option<String> = row.get("name")?;
         let version: Option<String> = row.get("version")?;
         let description: Option<String> = row.get("description")?;
@@ -29,6 +30,7 @@ impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
             description,
             homepage,
             long_description,
+            store_path,
         })
     }
 }


### PR DESCRIPTION
Why
===

should probably return all relevant info in search results (until cli refactor, which is looking increasingly likely)

What changed
============

added `storePath` to search output

Test plan
=========

1. `nix eval github:replit/rippkgs/cad/search-return-store-paths#lib.genRegistry --refresh --apply 'f: f builtins.currentSystem (import <nixpkgs> { config = { allowUnsupportedSystem = true; }; })' --impure --json >nixpkgs.json`
2. `nix run github:replit/rippkgs/cad/search-return-store-paths#rippkgs-index -- --output nixpkgs.sqlite --registry nixpkgs.json`
3. `nix run github:replit/rippkgs/cad/search-return-store-paths#rippkgs -- --index nixpkgs.sqlite rustc` should have results with `store_path`