### PR TITLE
genRegistry: use tryEval to get output paths

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -13,10 +13,14 @@ in {
         pname = safeVal.pname or (parseDrvName safeVal.name).name or null;
         version = safeVal.version or null;
         storePaths = let
-          outputs-list = map (out: {
+          getOutput = out: {
             name = out;
-            value = removePrefix "/nix/store/" safeVal.${out}.outPath;
-          }) (safeVal.outputs or []);
+            value = let
+              outPath = tryEval safeVal.${out}.outPath;
+            in if outPath.success then removePrefix "/nix/store/" outPath.value else "<broken>";
+          };
+
+          outputs-list = map getOutput (safeVal.outputs or []);
           relevant-outputs = filter ({name, ...}: name == "out") outputs-list;
         in
           listToAttrs relevant-outputs;


### PR DESCRIPTION
Why
===

nixpkgs-legacy was failing to eval the registry because some outpaths were failing to evaluate due to missing attributes

What changed
============

use `tryEval` to get outpaths. if the evaluation fails, put `<broken>` instead. this can be used for additional heuristics eventually :)

Test plan
=========

in `nix repl`:
1. `:lf github:replit/rippkgs/cad/try-eval-output-paths`
2. `pkgs = import inputs.nixpkgs {}`
3. `nixpkgs-legacy = pkgs.fetchzip { url = "https://storage.googleapis.com/replit-nixpkgs/nixpkgs-legacy.tar.gz"; hash = "sha256-RuT0H53ziB5gcCcnU6hI53i+UNQLR/UgWNvYmGH052c="; }`
4. `registry = lib.genRegistry builtins.currentSystem (import nixpkgs-legacy {})`
5. `builtins.toJSON registry` evaluates without error