### PR TITLE
search: optionally deserialize score

### DIFF
--- a/src/bin/search/data.rs
+++ b/src/bin/search/data.rs
@@ -9,6 +9,7 @@ pub struct Package {
     pub homepage: Option<String>,
     pub long_description: Option<String>,
     pub store_path: Option<String>,
+    pub score: Option<f64>,
 }
 
 impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
@@ -22,6 +23,7 @@ impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
         let description: Option<String> = row.get("description")?;
         let homepage: Option<String> = row.get("homepage")?;
         let long_description: Option<String> = row.get("long_description")?;
+        let score: Option<f64> = row.get("score").unwrap_or(None);
 
         Ok(Package {
             attribute,
@@ -31,6 +33,7 @@ impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
             homepage,
             long_description,
             store_path,
+            score,
         })
     }
 }


### PR DESCRIPTION
Why
===

when working on info for packages in `replit.nix` i found i'm getting errors with `--exact` due to failing to get the `score` column from an sqlite row. that's because we don't actually score exact results!

What changed
============

if there's an error `get`ting the `score` column ignore it

Test plan
=========

`cargo run --bin rippkgs -- -i <index> zsh --exact` doesn't error
