### PR TITLE
search: use XDG_DATA_HOME for default index location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "xdg",
 ]
 
 [[package]]
@@ -433,6 +434,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 rusqlite = { version = "0.30.0", features = ["functions"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
+xdg = "2.5.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
Why
===

convenience, and i'm gonna use this behavior on replit to deduplicate index location logic eventually

What changed
============

support implicit index location using `XDG_DATA_HOME`

Test plan
=========

1. `cargo run --bin rippkgs -- -i <path to index> --exact zsh` still works
2. `cargo run --bin rippkgs -- --exact zsh` doesn't work and fails with error about `~/.local/share/rippkgs-index.sqlite` not existing
3. `ln -s <abs path to index> ~/.local/share/rippkgs-index.sqlite`
4. `cargo run --bin rippkgs -- --exact zsh` works