### PR TITLE
flake: add aarch64-linux and x86_64-darwin targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
 
       systems = [
         "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
         "x86_64-linux"
       ];
 


### PR DESCRIPTION
Why
===

fixes #25

What changed
============

added `aarch64-linux` and `x86_64-darwin` targets to the flake

Test plan
=========

ci passes (`nix flake check` verifies the derivations)