### PR TITLE
set meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,7 @@
               inherit cargoArtifacts;
               pname = "rippkgs";
               cargoExtraArgs = "--bin rippkgs";
+              meta.mainProgram = "rippkgs";
             });
 
           rippkgs-index = craneLib.buildPackage (crane-common-args
@@ -123,6 +124,7 @@
               inherit cargoArtifacts;
               pname = "rippkgs-index";
               cargoExtraArgs = "--bin rippkgs-index";
+              meta.mainProgram = "rippkgs";
             });
         };
       };


### PR DESCRIPTION
Why
===

fixes #32 

What changed
============

set `meta.mainProgram` for both packages

Test plan
=========

```
$ nix repl
nix-repl> :lf .
nix-repl> (import <nixpkgs> {}).lib.getExe packages.aarch64-darwin.rippkgs
 # should print the path to the rippkgs binary
nix-repl> (import <nixpkgs> {}).lib.getExe packages.aarch64-darwin.rippkgs-index
 # should print the path to the rippkgs-index binary
```