### PR TITLE
add `present` field to Package results

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
               inherit cargoArtifacts;
               pname = "rippkgs-index";
               cargoExtraArgs = "--bin rippkgs-index";
-              meta.mainProgram = "rippkgs";
+              meta.mainProgram = "rippkgs-index";
             });
         };
       };

--- a/src/bin/index/data.rs
+++ b/src/bin/index/data.rs
@@ -63,6 +63,7 @@ impl PackageInfo {
             description: description.flatten(),
             long_description: long_description.flatten(),
             score: None,
+            present: None,
         }
     }
 }

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -121,6 +121,7 @@ fn write_index(index: &Path, registry: Registry) -> Result<()> {
                      description,
                      long_description,
                      score: _score, // score not included in the database
+                     ..
                  }| {
                     create_row_query
                         .execute(rusqlite::params![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub struct Package {
     pub long_description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub present: Option<bool>,
 }
 
 impl Package {
@@ -58,6 +61,7 @@ impl<'r, 'd> TryFrom<&'r rusqlite::Row<'d>> for Package {
             long_description,
             store_path,
             score,
+            present: Default::default(),
         })
     }
 }


### PR DESCRIPTION
Why
===

sometimes it's more useful to return whether a path is present than to just filter it out anyways

What changed
============

added new `present` field to the json output which returns whether a package is present

Test plan
=========

- ci passes
- `nix run .#rippkgs -- --json rust | jq` might have some results that are present and some that aren't
