### PR TITLE
fix mainProgram meta for rippkgs-index

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
               inherit cargoArtifacts;
               pname = "rippkgs-index";
               cargoExtraArgs = "--bin rippkgs-index";
-              meta.mainProgram = "rippkgs";
+              meta.mainProgram = "rippkgs-index";
             });
         };
       };


### PR DESCRIPTION
Why
===

`nix run .#rippkgs-index` broke because the main program is set to `rippkgs`

this wasn't caught in #36 because it was running the workflow from `main` :(

What changed
============

set `meta.mainProgram` of rippkgs-index to `rippkgs-index`

Test plan
=========

`nix run .#rippkgs-index` works again