### PR TITLE
make propagated build data optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "rippkgs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_matches",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rippkgs"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/bin/index/main.rs
+++ b/src/bin/index/main.rs
@@ -55,6 +55,10 @@ struct IndexNixpkgs {
     /// passing the `-I` flag to nix.
     nixpkgs: Option<PathBuf>,
 
+    /// Whether to include propagated build inputs in the index.
+    #[clap(long)]
+    build_propagated_inputs: bool,
+
     /// The location to write the saved index to.
     #[clap(short, long, default_value = "rippkgs-index.sqlite")]
     output: PathBuf,
@@ -170,6 +174,7 @@ fn index_nixpkgs(
         save_registry,
         nixpkgs_arg,
         nixpkgs,
+        build_propagated_inputs,
         ..
     }: &IndexNixpkgs,
 ) -> Result<Registry> {
@@ -178,7 +183,7 @@ fn index_nixpkgs(
 genRegistry:
 
 let pkgs = import <nixpkgs> {nixpkgs_arg};
-    genRegistry' = genRegistry pkgs;
+    genRegistry' = genRegistry (pkgs // {{ buildPropagatedInputs = {build_propagated_inputs}; }});
 in genRegistry' pkgs
         "#,
     );


### PR DESCRIPTION
Why
===

Including propagated build inputs increases build time and index size, so lets make it optional (disabled by default).

What changed
============

Added `--build_propagated_inputs` flag to `rippkgs-index` to optionally enable including `propagated{,Native}BuildInputs` in index.

Test plan
=========

