### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,12 +10,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: install Nix
-        uses: nixbuild/nix-quick-install-action@master
-      - name: Set up Nix cache
-        uses: nix-community/cache-nix-action@main
-        with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: use FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@main
       - run: nix flake check --all-systems
 
   e2e:
@@ -26,12 +23,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: install Nix
-        uses: nixbuild/nix-quick-install-action@master
-      - name: Set up Nix cache
-        uses: nix-community/cache-nix-action@main
-        with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: use FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@main
       - name: generate registry for inputs.nixpkgs
         run: nix run .#rippkgs-index -- nixpkgs -o rippkgs-index.sqlite "$(nix flake metadata --inputs-from . --json nixpkgs | jq -r .path)"
       - name: use jq

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,9 +10,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@master
+      - name: Set up Nix cache
+        uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - run: nix flake check --all-systems
 
   e2e:
@@ -23,9 +26,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: use Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@master
+      - name: Set up Nix cache
+        uses: nix-community/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - name: generate registry for inputs.nixpkgs
         run: nix run .#rippkgs-index -- nixpkgs -o rippkgs-index.sqlite "$(nix flake metadata --inputs-from . --json nixpkgs | jq -r .path)"
       - name: use jq


### PR DESCRIPTION
Why
===

The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works.


What changed
============

This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.

Test plan
=========

Run CI.
